### PR TITLE
[FIX] Use cache api defined in CacheInterface to load/get from cache.

### DIFF
--- a/src/services/OktaService.php
+++ b/src/services/OktaService.php
@@ -240,7 +240,7 @@ class OktaService
         $cacheKey = md5(sprintf('getUsersGroup-%d-%s-%s', $limit, $after, $groupID));
 
         // attempt to retrieve ArrayList of posts from cache
-        if (!($response = $cache->load($cacheKey))) {
+        if (!($response = $cache->get($cacheKey))) {
             $response = $this->OktaGateway->getUsersFromGroup($limit, $after, $groupID);
 
             if (!is_array($response)) {


### PR DESCRIPTION
Replace the method **load** used on an instance of a class using CacheInterface to the appropriate **get** method instead.