### PR TITLE
Change the header array key to use lowercase

### DIFF
--- a/src/services/OktaService.php
+++ b/src/services/OktaService.php
@@ -268,7 +268,7 @@ class OktaService
     private function getAfterFromLinkHeader($data)
     {
         $after = null;
-        $linkHeader = (isset($data['Headers']['Link'])) ? $data['Headers']['Link'] : null;
+        $linkHeader = (isset($data['Headers']['link'])) ? $data['Headers']['link'] : null;
 
         // parse the "Link" header
         if ($linkHeader) {


### PR DESCRIPTION
Sync data gets batched in lots of 100 and a key value pair is returned from Okta that tells the application if there is more results to be synced. This key's name has changed from Capitalization to lowercase.